### PR TITLE
Add multi-platform builds

### DIFF
--- a/.github/workflows/dockerize.yml
+++ b/.github/workflows/dockerize.yml
@@ -33,6 +33,12 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
@@ -41,6 +47,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1


### PR DESCRIPTION
Really cool project! I wanted to try it out on my ARM Mac and noticed that the container images are only built for x86_64. This adds ARM support for the images as well.

Successful workflow run can be found [here](https://github.com/tangowithfoxtrot/bunster/actions/runs/12857059743/job/35844479080). And the associated image that it published can be found [here](https://github.com/tangowithfoxtrot/bunster/pkgs/container/bunster/339492402?tag=v0.7.1).