### PR TITLE
Fix Unix-specific cross-device errors

### DIFF
--- a/cmd/bunster/build.go
+++ b/cmd/bunster/build.go
@@ -81,8 +81,6 @@ func buildCMD(_ context.Context, cmd *cli.Command) error {
 }
 
 func copyFileMode(dPath, sPath string) error {
-	var err error = nil
-
 	sFile, err := os.Open(sPath)
 	if err != nil {
 		return err
@@ -95,7 +93,7 @@ func copyFileMode(dPath, sPath string) error {
 	}
 	defer dFile.Close()
 
-	if _, err = io.Copy(dFile, sFile); err != nil {
+	if _, err := io.Copy(dFile, sFile); err != nil {
 		return err
 	}
 
@@ -104,11 +102,11 @@ func copyFileMode(dPath, sPath string) error {
 		return err
 	}
 
-	if err = os.Chmod(dPath, sStat.Mode()); err != nil {
+	if err := os.Chmod(dPath, sStat.Mode()); err != nil {
 		return err
 	}
 
-	if err = dFile.Sync(); err != nil {
+	if err := dFile.Sync(); err != nil {
 		return err
 	}
 

--- a/cmd/bunster/build.go
+++ b/cmd/bunster/build.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -72,11 +73,46 @@ func buildCMD(_ context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	if err := os.Rename(path.Join(wd, "build.bin"), cmd.String("o")); err != nil {
+	if err := copyFileMode(cmd.String("o"), path.Join(wd, "build.bin")); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func copyFileMode(dPath, sPath string) error {
+	var err error = nil
+
+	sFile, err := os.Open(sPath)
+	if err != nil {
+		return err
+	}
+	defer sFile.Close()
+
+	dFile, err := os.Create(dPath)
+	if err != nil {
+		return err
+	}
+	defer dFile.Close()
+
+	if _, err = io.Copy(dFile, sFile); err != nil {
+		return err
+	}
+
+	sStat, err := sFile.Stat()
+	if err != nil {
+		return err
+	}
+
+	if err = os.Chmod(dPath, sStat.Mode()); err != nil {
+		return err
+	}
+
+	if err = dFile.Sync(); err != nil {
+		return err
+	}
+
+	return err
 }
 
 func cloneRuntime(dst string) error {


### PR DESCRIPTION
[Rename](https://pkg.go.dev/os#Rename) has some OS-specific restrictions: when running the cli on a host where tmpdir's underlying mount point differs from working dir's one, errors are thrown:

```
Error: invalid cross-device link
```

This fix changes moving to copying.