### PR TITLE
Support `shift` builtin command

### DIFF
--- a/generator/compound.go
+++ b/generator/compound.go
@@ -220,7 +220,7 @@ func (g *generator) handleRangeLoop(buf *InstructionBuffer, loop ast.RangeLoop, 
 		g.generate(&body, statement, &context{})
 	}
 
-	var members = ir.Literal("shell.Args[1:]")
+	var members = ir.Literal("shell.Args")
 	if len(loop.Operands) > 0 {
 		cmdbuf.add(ir.DeclareSlice{Name: "members"})
 

--- a/generator/tests/14-embedding.test
+++ b/generator/tests/14-embedding.test
@@ -1,0 +1,30 @@
+#(TEST: can generate the [...] command)
+
+@embed path/to/file path/to/directory 
+
+#(RESULT)
+
+package main
+
+import (
+	"embed"
+	"github.com/yassinebenaid/bunster/runtime"
+	"io/fs"
+)
+
+//go:embed "embed/path/to/file"
+//go:embed "embed/path/to/directory"
+var embedFS embed.FS
+
+func Main(shell *runtime.Shell, streamManager *runtime.StreamManager) {
+	subfs, err := fs.Sub(&embedFS, "embed")
+	if err != nil {
+		shell.HandleError(streamManager, err)
+		return
+	}
+	shell.Embed = subfs
+}
+
+
+#(ENDTEST)
+

--- a/runtime/builtin/builtin.go
+++ b/runtime/builtin/builtin.go
@@ -9,6 +9,7 @@ func Register(shell *runtime.Shell) {
 	shell.RegisterFunction("false", False)
 	shell.RegisterFunction("loadenv", Loadenv)
 	shell.RegisterFunction("embed", Embed)
+	shell.RegisterFunction("shift", Shift)
 }
 
 func True(shell *runtime.Shell, stdin, stdout, stderr runtime.Stream) {

--- a/runtime/builtin/embed.go
+++ b/runtime/builtin/embed.go
@@ -16,13 +16,13 @@ func Embed(shell *runtime.Shell, stdin, stdout, stderr runtime.Stream) {
 		return
 	}
 
-	if len(shell.Args) != 3 {
+	if len(shell.Args) != 2 {
 		fmt.Fprintf(stderr, "embed: expected 2 arguments, got %d\n", len(shell.Args))
 		shell.ExitCode = 1
 		return
 	}
 
-	command, path := shell.Args[1], shell.Args[2]
+	command, path := shell.Args[0], shell.Args[1]
 
 	switch command {
 	case "cat":
@@ -52,7 +52,7 @@ func Embed(shell *runtime.Shell, stdin, stdout, stderr runtime.Stream) {
 
 		fmt.Fprintln(stdout, strings.Join(files, "\n"))
 	default:
-		fmt.Fprintf(stderr, "embed: %q is not a valid command\n", command)
+		fmt.Fprintf(stderr, "embed: %q is not a valid embed command\n", command)
 		shell.ExitCode = 1
 	}
 }

--- a/runtime/builtin/loadenv.go
+++ b/runtime/builtin/loadenv.go
@@ -17,7 +17,7 @@ func Loadenv(shell *runtime.Shell, stdin, stdout, stderr runtime.Stream) {
 	fs := flag.NewFlagSet("loadenv", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	export := fs.Bool("X", false, "mark variables as exported")
-	if err := fs.Parse(shell.Args[1:]); err != nil {
+	if err := fs.Parse(shell.Args); err != nil {
 		shell.ExitCode = 1
 		return
 	}

--- a/runtime/builtin/shift.go
+++ b/runtime/builtin/shift.go
@@ -8,22 +8,23 @@ import (
 )
 
 func Shift(shell *runtime.Shell, stdin, stdout, stderr runtime.Stream) {
-	if len(shell.Args) > 2 {
+	if len(shell.Args) > 1 {
 		fmt.Fprintf(stderr, "embed: expected 1 or 0 arguments, got %d\n", len(shell.Args))
 		shell.ExitCode = 1
 		return
 	}
 
-	if len(shell.Args) == 2 {
-		if n, err := strconv.Atoi(shell.Args[1]); err != nil {
-			fmt.Fprintf(stderr, "embed: bad argument, %v\n", err)
-			shell.ExitCode = 1
-			return
-		} else {
-			shell.Shift(n)
-		}
-	} else {
+	if len(shell.Args) < 1 {
 		shell.Shift(1)
+		return
+	}
+
+	if n, err := strconv.Atoi(shell.Args[0]); err != nil {
+		fmt.Fprintf(stderr, "embed: bad argument, %v\n", err)
+		shell.ExitCode = 1
+		return
+	} else {
+		shell.Shift(n)
 	}
 
 }

--- a/runtime/builtin/shift.go
+++ b/runtime/builtin/shift.go
@@ -20,7 +20,7 @@ func Shift(shell *runtime.Shell, stdin, stdout, stderr runtime.Stream) {
 	}
 
 	if n, err := strconv.Atoi(shell.Args[0]); err != nil {
-		fmt.Fprintf(stderr, "embed: bad argument, %v\n", err)
+		fmt.Fprintf(stderr, "embed: %q is not a valid integer\n", shell.Args[0])
 		shell.ExitCode = 1
 		return
 	} else {

--- a/runtime/builtin/shift.go
+++ b/runtime/builtin/shift.go
@@ -1,0 +1,29 @@
+package builtin
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/yassinebenaid/bunster/runtime"
+)
+
+func Shift(shell *runtime.Shell, stdin, stdout, stderr runtime.Stream) {
+	if len(shell.Args) > 2 {
+		fmt.Fprintf(stderr, "embed: expected 1 or 0 arguments, got %d\n", len(shell.Args))
+		shell.ExitCode = 1
+		return
+	}
+
+	if len(shell.Args) == 2 {
+		if n, err := strconv.Atoi(shell.Args[1]); err != nil {
+			fmt.Fprintf(stderr, "embed: bad argument, %v\n", err)
+			shell.ExitCode = 1
+			return
+		} else {
+			shell.Shift(n)
+		}
+	} else {
+		shell.Shift(1)
+	}
+
+}

--- a/runtime/shell.go
+++ b/runtime/shell.go
@@ -50,6 +50,16 @@ type Shell struct {
 	functions    *repository[PredefinedCommand]
 }
 
+func (shell *Shell) Shift(n int) {
+	args := shell.parent.Args[1:]
+
+	if n <= len(args) {
+		args = args[n:]
+	}
+
+	shell.parent.Args = append(shell.parent.Args[:1], args...)
+}
+
 func (shell *Shell) ReadVar(name string) string {
 	if value, ok := shell.getLocalVar(name); ok {
 		return value

--- a/stubs/main.go.stub
+++ b/stubs/main.go.stub
@@ -11,7 +11,8 @@ import (
 func main() {
 	shell := runtime.NewShell()
 	shell.PID = os.Getpid()
-	shell.Args = os.Args
+	shell.Path = os.Args[0]
+	shell.Args = os.Args[1:]
 
     builtin.Register(shell)
 

--- a/tests/12-embedding.yml
+++ b/tests/12-embedding.yml
@@ -94,3 +94,29 @@ cases:
         ---
         file.txt
         file2.txt
+
+  - name: embed command expects exactly 2 arguments
+    setup_shell: |
+      cat <<<"foobar" >file.txt
+    script: |
+      @embed file.txt
+
+      embed arg1 arg2 arg3
+      embed arg1
+    expect:
+      exit_code: 1
+      stderr: |
+        embed: expected 2 arguments, got 3
+        embed: expected 2 arguments, got 1
+
+  - name: embed command expects valid arguments
+    setup_shell: |
+      cat <<<"foobar" >file.txt
+    script: |
+      @embed file.txt
+
+      embed cmd file.txt
+    expect:
+      exit_code: 1
+      stderr: |
+        embed: "cmd" is not a valid embed command

--- a/tests/13-positionals-shifting.yml
+++ b/tests/13-positionals-shifting.yml
@@ -1,0 +1,44 @@
+cases:
+  - name: can shift positional arguments
+    args: [foo, bar, baz]
+    script: |
+
+      echo "1:$1 2:$2 3:$3"
+
+      shift
+
+      echo "1:$1 2:$2 3:$3"
+
+      shift
+
+      echo "1:$1 2:$2 3:$3"
+
+      shift
+
+      echo "1:$1 2:$2 3:$3"
+    expect:
+      stdout: |
+        1:foo 2:bar 3:baz
+        1:bar 2:baz 3:
+        1:baz 2: 3:
+        1: 2: 3:
+
+  - name: can shift positional arguments with a specific degree
+    args: [foo, bar, baz]
+    script: |
+
+      echo "1:$1 2:$2 3:$3"
+
+      shift 2
+
+      echo "1:$1 2:$2 3:$3"
+
+      shift
+
+      echo "1:$1 2:$2 3:$3"
+
+    expect:
+      stdout: |
+        1:foo 2:bar 3:baz
+        1:baz 2: 3:
+        1: 2: 3:

--- a/tests/13-positionals-shifting.yml
+++ b/tests/13-positionals-shifting.yml
@@ -42,3 +42,142 @@ cases:
         1:foo 2:bar 3:baz
         1:baz 2: 3:
         1: 2: 3:
+
+  - name: can shift positional arguments with a degree out of range
+    args: [foo, bar, baz]
+    script: |
+
+      echo "1:$1 2:$2 3:$3"
+
+      shift 99
+
+      echo "1:$1 2:$2 3:$3"
+
+      shift
+
+      echo "1:$1 2:$2 3:$3"
+
+    expect:
+      stdout: |
+        1:foo 2:bar 3:baz
+        1: 2: 3:
+        1: 2: 3:
+
+  - name: can shift positional arguments within a function
+    script: |
+
+      function func() {
+          echo "1:$1 2:$2 3:$3"
+
+          shift
+
+          echo "1:$1 2:$2 3:$3"
+
+          shift
+
+          echo "1:$1 2:$2 3:$3"
+
+          shift
+
+          echo "1:$1 2:$2 3:$3"
+      }
+
+      func foo bar baz
+
+    expect:
+      stdout: |
+        1:foo 2:bar 3:baz
+        1:bar 2:baz 3:
+        1:baz 2: 3:
+        1: 2: 3:
+
+  - name: can shift positional arguments within a function with specific degree
+    script: |
+
+      function func() {
+          echo "1:$1 2:$2 3:$3"
+
+          shift 2
+
+          echo "1:$1 2:$2 3:$3"
+
+          shift
+
+          echo "1:$1 2:$2 3:$3"
+      }
+
+      func foo bar baz
+
+    expect:
+      stdout: |
+        1:foo 2:bar 3:baz
+        1:baz 2: 3:
+        1: 2: 3:
+
+  - name: can shift positional arguments with a degree out of range in functions
+    script: |
+
+      function func() {
+
+          echo "1:$1 2:$2 3:$3"
+
+          shift 99
+
+          echo "1:$1 2:$2 3:$3"
+
+          shift
+
+          echo "1:$1 2:$2 3:$3"
+      }
+
+      func foo bar baz
+    expect:
+      stdout: |
+        1:foo 2:bar 3:baz
+        1: 2: 3:
+        1: 2: 3:
+
+  - name: shifting positional arguments withing a function does not affect global args
+    args: [foo, bar]
+    script: |
+      echo $@
+
+      function func() {
+          echo $@
+
+          shift 
+
+          echo $@
+      }
+
+      func boo baz
+      echo $@
+
+    expect:
+      stdout: |
+        foo bar
+        boo baz
+        baz
+        foo bar
+
+  - name: shifting positional arguments withing a sub-shell does not affect global args
+    args: [foo, bar]
+    script: |
+      echo $@
+
+      (
+          echo $@
+
+          shift 
+
+          echo $@
+      )
+
+      echo $@
+
+    expect:
+      stdout: |
+        foo bar
+        foo bar
+        bar
+        foo bar

--- a/tests/13-positionals-shifting.yml
+++ b/tests/13-positionals-shifting.yml
@@ -181,3 +181,17 @@ cases:
         foo bar
         bar
         foo bar
+
+  - name: shift command expects 0 or 1 arguments only
+    script: |
+      shift 1 2 3
+    expect:
+      exit_code: 1
+      stderr: "embed: expected 1 or 0 arguments, got 3\n"
+
+  - name: shift command expects valid integer
+    script: |
+      shift foo
+    expect:
+      exit_code: 1
+      stderr: "embed: \"foo\" is not a valid integer\n"


### PR DESCRIPTION
`shift` command is used to shift positional arguments

```sh
shift

# or

shift 2
```