### PR TITLE
Add single-file mode support.

### DIFF
--- a/cmd/bunster/main.go
+++ b/cmd/bunster/main.go
@@ -34,8 +34,13 @@ func main() {
 				},
 			},
 			{
-				Name:   "build",
-				Usage:  "Build a module",
+				Name:  "build",
+				Usage: "Build a module",
+				Description: "The build command compiles the source code to Go code, and then uses the go tool-chain\n" +
+					"to build the binary for you.\n\n" +
+					"If no arguments are supplied, the build command assumes that current directory is a bunster module \n" +
+					"and looks for the file [main.sh]. then loads all other .sh files in the curren directory as declaration files.\n\n" +
+					"Otherwise, if a file path is supplied as the first argument. only that file is compiled.",
 				Action: build,
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "o", Required: true},
@@ -43,7 +48,7 @@ func main() {
 			},
 			{
 				Name:   "generate",
-				Usage:  "Generate the Go source out of a module",
+				Usage:  "Generate the Go source out of a module, this command adheres to same rules as the build command.",
 				Action: geneate,
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "o", Required: true},

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,6 +8,7 @@ echo "Hello World"
 ```
 
 ## Build
+
 To build this script, simply run:
 
 ```shell
@@ -32,3 +33,40 @@ bunster generate script.sh -o my-module
 ```
 
 This will create a directory program named `my-module` in which the Go source is generated.
+
+## Modules mode
+
+> [!INFO]
+> You can learn more about bunster modules [here](/workspace/modules)
+
+If no arguments are supplied, the `build` and `generate` commands assume that current directory is a bunster module
+and looks for the file `main.sh`.
+
+Then loads all `.sh` files in the curren directory as declaration files. Otherwise, if a file path is supplied as the first argument. only that file is processed.
+
+for example:
+
+```txt
+├── main.sh
+├── utils.sh
+└── functions.sh
+```
+
+If you run:
+
+```sh
+bunster build -o test
+```
+
+bunster assumes this is a module. and starts by loading `main.sh` as an entry point. then processes all of `utils.sh` and `functions.sh` as declaration scripts.
+
+However, if you supplied a path like this:
+
+```sh
+bunster build main.sh -o test
+```
+
+bunster only processes the `main.sh` file and ignores all other files. and modules mode is turned off. this means no use of `bunster.yml`.
+
+> [!IMPORTANT]
+> In first case. the file extension matters. bunster only processes `.sh` files. **BUT**, in the second case. the file extension **does not matter**. This means you can build any file with whatever extension. `bunster build foo.any -o test`.


### PR DESCRIPTION
This PR changes a little bit in the behavior of `build` and `generate` commands.

running `bunster build -o test` assumes this is a bunster module. and looks for `main.sh` as entry point. then processes all `.sh` files in current directory as part of the module.

However, if you do supply a file path: `bunster build file/to/path -o test`. only that file is processed and modules-mode is turned off.

learn more about this behavior [here](https://bunster.netlify.app/cli)

Related: #271 