### PR TITLE
Remove `brew tap` step from installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ curl -f https://bunster.netlify.app/install.sh | GLOBAL=1 bash
 ### Homebrew
 
 ```sh
-brew tap yassinebenaid/bunster
 brew install bunster
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,7 +29,6 @@ curl -f https://bunster.netlify.app/install.sh | GLOBAL=1 bash
 ## Homebrew
 
 ```sh
-brew tap yassinebenaid/bunster
 brew install bunster
 ```
 


### PR DESCRIPTION
That's possible now due to the formula being part of homebrew-core as of https://github.com/Homebrew/homebrew-core/pull/234691.
