### PR TITLE
fix(docs): correct stderr redirection typos in redirections examples

### DIFF
--- a/docs/features/redirections.md
+++ b/docs/features/redirections.md
@@ -84,7 +84,7 @@ This is semantically equivalent to:
 echo "Hello World" &>file.txt 
 
 # Or
-echo "Hello World" 1>file.txt 2>&2
+echo "Hello World" 1>file.txt 2>&1
 ```
 
 ## Appending standard output and standard error
@@ -107,7 +107,7 @@ This is semantically equivalent to:
 echo "Hello World" &>>file.txt 
 
 # Or
-echo "Hello World" 1>>file.txt 2>&2
+echo "Hello World" 1>>file.txt 2>&1
 ```
 
 ## Here string


### PR DESCRIPTION
Fixes #282

## Problem

The documentation examples for redirecting both stdout and stderr contain a typo: `2>&2` redirects stderr to itself, which is incorrect.

## Solution

Change `2>&2` to `2>&1` so that stderr is correctly redirected to stdout (which is already pointing to the file).

## Changes

Fixed in `docs/features/redirections.md`:
- Line 87: `echo "Hello World" 1>file.txt 2>&2` → `2>&1`
- Line 110: `echo "Hello World" 1>>file.txt 2>&2` → `2>&1`
